### PR TITLE
implement debug logging

### DIFF
--- a/discordbot1.py
+++ b/discordbot1.py
@@ -3,6 +3,7 @@
 
 import os
 import re
+import logging
 
 # pip
 import discord
@@ -13,6 +14,12 @@ import joke
 
 # pip
 from mcstatus import MinecraftServer
+
+logger = logging.getLogger("discord")
+logger.setLevel(logging.DEBUG)
+handler = logging.FileHandler(filename="discord.log", encoding="utf-8", mode="w")
+handler.setFormatter(logging.Formatter("%(asctime)s:%(levelname)s:%(name)s: %(message)s"))
+logger.addHandler(handler)
 
 CMD_PREFIX = "\\"
 TRANSLATE_CMD = CMD_PREFIX + "t "


### PR DESCRIPTION
* discordbot1.py があるのと同じディレクトリ内にデバッグログ discord.log を吐き出すようにログ機能の追加。
  * 何か問題があった際の切り分け等をしやすくするため
  * 今後は print() を使わず logging.info() とかでBetterな実装ができそう
  * see: https://discordpy.readthedocs.io/ja/latest/logging.html
